### PR TITLE
Add requirements.txt for use with pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+wordfreq
+numpy


### PR DESCRIPTION
Requirements can be installed by running e.g. `pip3 install -r requirements.txt`